### PR TITLE
Add Color Preferences subpage

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -484,6 +484,12 @@
             id="org.sasylf.preferences.PreferencePage"
             name="SASyLF Preferences">
       </page>
+      <page
+            name="Colors"
+            category="org.sasylf.preferences.PreferencePage"
+            class="org.sasylf.preferences.PreferencePageColors"
+            id="org.sasylf.preferences.PreferencePageColors">
+      </page>
    </extension>
    <extension
          point="org.eclipse.core.runtime.preferences">

--- a/src/org/sasylf/editors/ProofViewerConfiguration.java
+++ b/src/org/sasylf/editors/ProofViewerConfiguration.java
@@ -43,7 +43,8 @@ public class ProofViewerConfiguration extends TextSourceViewerConfiguration {
 		reconciler.setDamager (dr, IDocument.DEFAULT_CONTENT_TYPE);
 		reconciler.setRepairer (dr, IDocument.DEFAULT_CONTENT_TYPE);
 
-		dr = new DefaultDamagerRepairer (new SingleTokenScanner(new TextAttribute (provider.getColor(SASyLFColorProvider.MULTI_LINE_COMMENT))));
+		dr = new DefaultDamagerRepairer (new SingleTokenScanner(new TextAttribute (
+				provider.getColor(SASyLFColorProvider.Fragments.MultiLineComment))));
 		reconciler.setDamager (dr, "__java_multiline_comment");
 		reconciler.setRepairer (dr, "__java_multiline_comment");
 		return reconciler;

--- a/src/org/sasylf/editors/SASyLFCodeScanner.java
+++ b/src/org/sasylf/editors/SASyLFCodeScanner.java
@@ -45,13 +45,13 @@ public class SASyLFCodeScanner extends RuleBasedScanner{
 	};*/
 
 	public SASyLFCodeScanner(SASyLFColorProvider provider)	{
-		TextAttribute kwAtt = new TextAttribute (provider.getColor(SASyLFColorProvider.KEYWORD), null,SWT.BOLD);
+		TextAttribute kwAtt = new TextAttribute (provider.getColor(SASyLFColorProvider.Fragments.Keyword), null,SWT.BOLD);
 		Token keyword = new Token (kwAtt);
 
-		IToken comment = new Token (new TextAttribute (provider.getColor(SASyLFColorProvider.SINGLE_LINE_COMMENT)));
-		IToken other = new Token (new TextAttribute (provider.getColor(SASyLFColorProvider.DEFAULT)));
-		IToken multiLineComment = new Token (new TextAttribute (provider.getColor(SASyLFColorProvider.MULTI_LINE_COMMENT)));
-		IToken rule = new Token (new TextAttribute (provider.getColor(SASyLFColorProvider.RULE)));
+		IToken comment = new Token (new TextAttribute (provider.getColor(SASyLFColorProvider.Fragments.SingleLineComment)));
+		IToken other = new Token (new TextAttribute (provider.getColor(SASyLFColorProvider.Fragments.Default)));
+		IToken multiLineComment = new Token (new TextAttribute (provider.getColor(SASyLFColorProvider.Fragments.MultiLineComment)));
+		IToken rule = new Token (new TextAttribute (provider.getColor(SASyLFColorProvider.Fragments.Rule)));
 
 		List<IRule> rules = new ArrayList<IRule> ();
 		rules.add (new EndOfLineRule ("//", comment));
@@ -91,7 +91,7 @@ public class SASyLFCodeScanner extends RuleBasedScanner{
 						while (c != ICharacterScanner.EOF && fDetector.isWordPart((char) c));
 						scanner.unread();
 
-						IToken token = (IToken) fWords.get(_buffer.toString()/*.toLowerCase()*/);
+						IToken token = fWords.get(_buffer.toString()/*.toLowerCase()*/);
 						if(token != null) {
 							return token;
 						}

--- a/src/org/sasylf/editors/SASyLFColorProvider.java
+++ b/src/org/sasylf/editors/SASyLFColorProvider.java
@@ -4,25 +4,63 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.jface.preference.PreferenceConverter;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.widgets.Display;
+import org.sasylf.Activator;
+import org.sasylf.preferences.PreferenceConstants;
 
 public class SASyLFColorProvider {
 
-	public static final RGB MULTI_LINE_COMMENT = new RGB(0, 128, 0);
-	public static final RGB SINGLE_LINE_COMMENT = new RGB(0, 128, 0);
-	public static final RGB KEYWORD = new RGB(0, 0, 128);
-	public static final RGB DEFAULT = new RGB(0, 0, 0);
-	public static final RGB BACKGROUND = new RGB(255, 255, 255);
-	public static final RGB RULE = new RGB(127, 0, 85);
+	static enum Fragments { 
+		Default, Keyword,
+		Background, Rule,
+		MultiLineComment, SingleLineComment };
+
+	public RGB MULTI_LINE_COMMENT;
+	public RGB SINGLE_LINE_COMMENT;
+	public RGB KEYWORD;
+	public RGB DEFAULT;
+	public RGB BACKGROUND;
+	public RGB RULE;
+
+	public static final RGB DEF_MULTI_LINE_COMMENT = new RGB(0, 128, 0);
+	public static final RGB DEF_SINGLE_LINE_COMMENT = new RGB(0, 128, 0);
+	public static final RGB DEF_KEYWORD = new RGB(0, 0, 128);
+	public static final RGB DEF_DEFAULT = new RGB(0, 0, 0);
+	public static final RGB DEF_BACKGROUND = new RGB(255, 255, 255);
+	public static final RGB DEF_RULE = new RGB(127, 0, 85);
 
 	protected Map<RGB, Color> _colorTable = new HashMap<RGB, Color>(10);
+
+	public SASyLFColorProvider() {
+		IPreferenceStore pStore = Activator.getDefault().getPreferenceStore();
+		DEFAULT = PreferenceConverter.getColor(pStore, PreferenceConstants.PREF_COLOR_DEFAULT);
+		KEYWORD = PreferenceConverter.getColor(pStore, PreferenceConstants.PREF_COLOR_KEYWORD);
+		RULE    = PreferenceConverter.getColor(pStore, PreferenceConstants.PREF_COLOR_RULE);
+		BACKGROUND = PreferenceConverter.getColor(pStore, PreferenceConstants.PREF_COLOR_BACKGROUND);
+		MULTI_LINE_COMMENT  = PreferenceConverter.getColor(pStore, PreferenceConstants.PREF_COLOR_ML_COMMENT);
+		SINGLE_LINE_COMMENT = PreferenceConverter.getColor(pStore, PreferenceConstants.PREF_COLOR_SL_COMMENT);
+	}
 
 	public void dispose(){
 		Iterator<Color> e = _colorTable.values().iterator();
 		while(e.hasNext()){
 			e.next().dispose();
+		}
+	}
+
+	public Color getColor(Fragments f){
+		switch (f) {
+		case Default: return getColor(DEFAULT);
+		case Keyword: return getColor(KEYWORD);
+		case Rule:    return getColor(RULE);
+		case Background:        return getColor(BACKGROUND);
+		case MultiLineComment:  return getColor(MULTI_LINE_COMMENT);
+		case SingleLineComment: return getColor(SINGLE_LINE_COMMENT);
+		default: throw new IllegalArgumentException("Unknown fragment to colorize: " + f);
 		}
 	}
 

--- a/src/org/sasylf/preferences/PreferenceConstants.java
+++ b/src/org/sasylf/preferences/PreferenceConstants.java
@@ -15,4 +15,13 @@ public class PreferenceConstants {
 	public static final String COMPULSORY_WHERE_CLAUSES = "org.sasylf.proof.compwhere";
 	
 	public static final String EXPERIMENTAL_FEATURES = "org.sasylf.proof.experimental";
+
+	// Preferences for syntax highlighting colors
+	public static final String PREF_COLOR_DEFAULT = "Pref_Color_Default";
+	public static final String PREF_COLOR_KEYWORD = "Pref_Color_Keyword";
+	public static final String PREF_COLOR_RULE =    "Pref_Color_Rule";
+	public static final String PREF_COLOR_BACKGROUND = "Pref_Color_Background";
+	public static final String PREF_COLOR_ML_COMMENT = "Pref_Color_Multiline_Comment";
+	public static final String PREF_COLOR_SL_COMMENT = "Pref_Color_Singleline_Comment";
+
 }

--- a/src/org/sasylf/preferences/PreferenceInitializer.java
+++ b/src/org/sasylf/preferences/PreferenceInitializer.java
@@ -2,7 +2,9 @@ package org.sasylf.preferences;
 
 import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer;
 import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.jface.preference.PreferenceConverter;
 import org.sasylf.Activator;
+import org.sasylf.editors.SASyLFColorProvider;
 
 /**
  * Class used to initialize default preference values.
@@ -24,11 +26,21 @@ public class PreferenceInitializer extends AbstractPreferenceInitializer {
 		store.setDefault(PreferenceConstants.COMPULSORY_WHERE_CLAUSES, true);
 		store.setDefault(PreferenceConstants.EXPERIMENTAL_FEATURES, "");
 		initializeEditorPreferences(store);
+		initializeColorPreferences(store);
 	}
 	
 	public static void initializeEditorPreferences(IPreferenceStore store) {
 		store.setDefault(PreferenceConstants.EDITOR_MATCHING_BRACKETS, true);
 		store.setDefault(PreferenceConstants.EDITOR_MATCHING_BRACKETS_COLOR, "127,0,85");		
+	}
+
+	public static void initializeColorPreferences(IPreferenceStore pStore) {
+		PreferenceConverter.setDefault(pStore, PreferenceConstants.PREF_COLOR_DEFAULT, SASyLFColorProvider.DEF_DEFAULT);
+		PreferenceConverter.setDefault(pStore, PreferenceConstants.PREF_COLOR_KEYWORD, SASyLFColorProvider.DEF_KEYWORD);
+		PreferenceConverter.setDefault(pStore, PreferenceConstants.PREF_COLOR_RULE, SASyLFColorProvider.DEF_RULE);
+		PreferenceConverter.setDefault(pStore, PreferenceConstants.PREF_COLOR_BACKGROUND, SASyLFColorProvider.DEF_BACKGROUND);
+		PreferenceConverter.setDefault(pStore, PreferenceConstants.PREF_COLOR_ML_COMMENT, SASyLFColorProvider.DEF_MULTI_LINE_COMMENT);
+		PreferenceConverter.setDefault(pStore, PreferenceConstants.PREF_COLOR_SL_COMMENT, SASyLFColorProvider.DEF_SINGLE_LINE_COMMENT);
 	}
 
 }

--- a/src/org/sasylf/preferences/PreferencePageColors.java
+++ b/src/org/sasylf/preferences/PreferencePageColors.java
@@ -1,0 +1,38 @@
+package org.sasylf.preferences;
+
+import org.eclipse.jface.preference.ColorFieldEditor;
+import org.eclipse.jface.preference.FieldEditorPreferencePage;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchPreferencePage;
+import org.sasylf.Activator;
+
+public class PreferencePageColors
+extends FieldEditorPreferencePage
+implements IWorkbenchPreferencePage {
+
+	public PreferencePageColors() {
+		super(GRID);
+	}
+
+	@Override
+	public void createFieldEditors() {
+		ColorFieldEditor def = new ColorFieldEditor(PreferenceConstants.PREF_COLOR_DEFAULT, "Default text", getFieldEditorParent());
+		addField(def);
+		ColorFieldEditor key = new ColorFieldEditor(PreferenceConstants.PREF_COLOR_KEYWORD, "Keyword text", getFieldEditorParent());
+		addField(key);
+		ColorFieldEditor rule = new ColorFieldEditor(PreferenceConstants.PREF_COLOR_RULE, "Rule text", getFieldEditorParent());
+		addField(rule);
+		ColorFieldEditor bg = new ColorFieldEditor(PreferenceConstants.PREF_COLOR_BACKGROUND, "Background", getFieldEditorParent());
+		addField(bg);
+		ColorFieldEditor ml = new ColorFieldEditor(PreferenceConstants.PREF_COLOR_ML_COMMENT, "Multi-line comments", getFieldEditorParent());
+		addField(ml);
+		ColorFieldEditor sl = new ColorFieldEditor(PreferenceConstants.PREF_COLOR_SL_COMMENT, "Single-line comments", getFieldEditorParent());
+		addField(sl);
+	}
+
+	@Override
+	public void init(IWorkbench workbench) {
+		setPreferenceStore(Activator.getDefault().getPreferenceStore());
+		setDescription("SASyLF Syntax Highlighting Colors (require reload to apply)");
+	}
+}


### PR DESCRIPTION
Eclipse has color "themes" for a while now, which basically allow choosing between the light (“classic”) and dark theme.

![Screenshot from 2020-11-22 18-16-59](https://user-images.githubusercontent.com/6832600/99920032-fdfd3300-2cee-11eb-8788-3971fc31913e.png)

SASyLF colors have been hard-coded, which make it hardly usable in the dark theme:

![Screenshot from 2020-11-22 17-50-54](https://user-images.githubusercontent.com/6832600/99920068-2d13a480-2cef-11eb-86e0-0788ffff579d.png)

With this patch one can set the colors as they like:

![Screenshot from 2020-11-22 18-25-20](https://user-images.githubusercontent.com/6832600/99920241-26d1f800-2cf0-11eb-88cd-fd0e21a2f347.png)

Control over highlighting is provided via a dedicated preference subpage:

![Screenshot from 2020-11-22 18-21-28](https://user-images.githubusercontent.com/6832600/99920152-9c899400-2cef-11eb-8529-3d3dab627946.png)

Admittedly, this is a very low-tech patch. The color-picking as implemented in major plugins is more sophisticated; e.g. they give a preview and, more importantly, don't require restarting. This patch provides a bare minimum for someone who wants to use SASyLF in the Eclipse dark theme.